### PR TITLE
Hotfix/caps extention support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ finally run
 php artisan vendor:publish --provider="Intervention\Image\ImageServiceProviderLaravel5"
 ```
 
+#### Configure for public folder
+Modify the configuration in `config/nodes/assets/general.php`
+```php
+return [
+    'upload' => [
+        'provider' => function () {
+            return new \Nodes\Assets\Upload\Providers\PublicFolder();
+        },
+    ],
+    'url'    => [
+        'provider' => function () {
+            return new \Nodes\Assets\Url\Providers\PublicFolder();
+        },
+    ],
+];
+```
+
 
 ## ⚙ Usage
 

--- a/config/providers/publicFolder.php
+++ b/config/providers/publicFolder.php
@@ -23,4 +23,26 @@ return [
     | The domain of the public folder
     */
     'domain'    => env('APP_NAME').'.'.env('APP_DOMAIN'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Mapping of file extension to mime types
+    |--------------------------------------------------------------------------
+    |
+    | All mime types from this list will be put in the image folder
+    | where there is support for resize
+    |
+    |
+    */
+    'imageExtensionMimeTypes' => [
+        'jpg'   => 'image/jpeg',
+        'jpeg'  => 'image/jpeg',
+        'pjpg'  => 'image/pjpeg',
+        'pjpeg' => 'image/pjpeg',
+        'png'   => 'image/png',
+        'gif'   => 'image/gif',
+        'svg'   => 'image/svg+xml',
+        'svgz'  => 'image/svg+xml',
+        'tiff'  => 'image/tiff',
+    ],
 ];

--- a/src/Upload/Providers/PublicFolder.php
+++ b/src/Upload/Providers/PublicFolder.php
@@ -29,6 +29,11 @@ class PublicFolder extends AbstractUploadProvider
      */
     protected function store(UploadedFile $uploadedFile, Settings $settings)
     {
+        // Fallback folder is none is set
+        if (! $settings->hasFolder()) {
+            $settings->setFolder('default');
+        }
+
         try {
             // Retrieve folder path
             $path = public_path(config('nodes.assets.providers.publicFolder.subFolder')).DIRECTORY_SEPARATOR.$settings->getFolder();

--- a/src/Upload/Settings.php
+++ b/src/Upload/Settings.php
@@ -175,7 +175,7 @@ class Settings
     public function getFilePath()
     {
         // Generate filename with extension
-        $path = $this->fileName.'.'.$this->fileExtension;
+        $path = $this->fileName . '.' . strtolower($this->fileExtension);
 
         // Prepend folder if present
         if ($this->hasFolder()) {


### PR DESCRIPTION
- Uploaded images on public folder filesystem now gets a default folder if none has been defined, just like on s3
- Added missing mimetype config for public folder
- Forced lower case extensions when generating file path in folder settings class
