### PR TITLE
Update all method to be compatible with Illuminate\Http\Request::all(…

### DIFF
--- a/src/Http/Requests/CdnRequest.php
+++ b/src/Http/Requests/CdnRequest.php
@@ -49,7 +49,7 @@ class CdnRequest extends FormRequest
      * @access public
      * @return array
      */
-    public function all()
+    public function all($keys = NULL)
     {
         $data = parent::all();
 


### PR DESCRIPTION
Laravel 5.5 is throwing the following error:
Declaration of Nodes\Assets\Http\Requests\CdnRequest::all() should be compatible with Illuminate\Http\Request::all($keys = NULL).

CdnRequest's all() method updated to have parameters of ($keys = NULL)